### PR TITLE
fix: move import of futures in tests to top of file

### DIFF
--- a/debian/patches/import_futures.diff
+++ b/debian/patches/import_futures.diff
@@ -1,0 +1,15 @@
+--- a/Lib/test/test_concurrent_futures/test_future.py
++++ b/Lib/test/test_concurrent_futures/test_future.py
+@@ -1,9 +1,9 @@
+-import threading
+-import time
+-import unittest
+ from concurrent import futures
+ from concurrent.futures._base import (
+     PENDING, RUNNING, CANCELLED, CANCELLED_AND_NOTIFIED, FINISHED, Future)
++import threading
++import time
++import unittest
+ 
+ from test import support
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -24,3 +24,4 @@ pydoc-use-pager.diff
 argparse-no-shutil.diff
 0028-sysconfigdata-name.patch
 0029-destshared-location.patch
+import_futures.diff


### PR DESCRIPTION
Fixes the `SyntaxError: from __future__ imports must occur at the beginning of the file` error during installation on Debian 11.